### PR TITLE
Fix words overlapping menu bug

### DIFF
--- a/style.css
+++ b/style.css
@@ -84,6 +84,7 @@ html {
 /* --------- Nav menu ---------- */
 
 .navigation {
+    z-index: 1;
     width : 100vw;
     position: fixed;
     top: 0;


### PR DESCRIPTION
in mobile display words from the background appear over the menu when the menu-links are  displayed